### PR TITLE
custom test utils

### DIFF
--- a/src/components/favorites-empty-screen/__snapshots__/favorites-empty-screen.snap.test.js.snap
+++ b/src/components/favorites-empty-screen/__snapshots__/favorites-empty-screen.snap.test.js.snap
@@ -44,10 +44,14 @@ exports[`Should FavoritesEmptyScreen render correctly 1`] = `
                   class="header__nav-link header__nav-link--profile"
                   href="/favorites"
                 >
+                  <div
+                    class="header__avatar-wrapper user__avatar-wrapper"
+                    style="background-image: url(undefined);"
+                  />
                   <span
                     class="header__user-name user__name"
                   >
-                    Sign in
+                    test@test.ru
                   </span>
                 </a>
               </li>
@@ -118,6 +122,5 @@ exports[`Should FavoritesEmptyScreen render correctly 1`] = `
       </a>
     </footer>
   </div>
-  );
 </div>
 `;

--- a/src/components/favorites-empty-screen/favorites-empty-screen.snap.test.js
+++ b/src/components/favorites-empty-screen/favorites-empty-screen.snap.test.js
@@ -1,23 +1,20 @@
 import React from "react";
-import {Router} from 'react-router-dom';
-import {render} from "@testing-library/react";
+import {render} from "../../utils/test-utils";
 import FavoritesEmptyScreen from "./favorites-empty-screen";
-import browserHistory from "../../history";
-import * as redux from "react-redux";
-import configureStore from "redux-mock-store";
 
-const mockStore = configureStore({});
+const testStore = {
+  USER: {
+    user: {
+      email: `test@test.ru`,
+      name: `Name`,
+    }
+  }
+};
 
 it(`Should FavoritesEmptyScreen render correctly`, () => {
   const {container} = render(
-      <redux.Provider store={mockStore({
-        USER: {
-          user: null
-        }
-      })}>
-        <Router history={browserHistory}>
-          <FavoritesEmptyScreen/>
-        </Router>);
-      </redux.Provider>);
+      <FavoritesEmptyScreen/>,
+      {store: testStore},
+  );
   expect(container).toMatchSnapshot();
 });

--- a/src/components/header/__snapshots__/header.snap.test.js.snap
+++ b/src/components/header/__snapshots__/header.snap.test.js.snap
@@ -55,3 +55,73 @@ exports[`Header tests Should Header render correctly 1`] = `
   </header>
 </div>
 `;
+
+exports[`Header tests Should Header render correctly when is not favorite Screen 1`] = `
+<div>
+  <header
+    class="header"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="header__wrapper"
+      >
+        <div
+          class="header__left"
+        >
+          <a
+            class="header__logo-link header__logo-link--active"
+            href="/"
+          >
+            <img
+              alt="6 cities logo"
+              class="header__logo"
+              height="41"
+              src="img/logo.svg"
+              width="81"
+            />
+          </a>
+        </div>
+        <nav
+          class="header__nav"
+        >
+          <ul
+            class="header__nav-list"
+            style="flex-direction: column; align-items: flex-end;"
+          >
+            <li
+              class="header__nav-item user"
+            >
+              <a
+                class="header__nav-link header__nav-link--profile"
+                href="/favorites"
+              >
+                <span
+                  class="header__user-name user__name"
+                >
+                  Sign in
+                </span>
+              </a>
+            </li>
+            <li
+              class="header__nav-item user"
+              style="margin-left: 15px;"
+            >
+              <a
+                class="header__nav-link header__nav-link--profile"
+              >
+                <span
+                  class="header__user-name user__name"
+                >
+                  Logout
+                </span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </header>
+</div>
+`;

--- a/src/components/header/header.snap.test.js
+++ b/src/components/header/header.snap.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import * as redux from 'react-redux';
+import {Provider} from 'react-redux';
 import {Router} from 'react-router-dom';
 import {render} from "@testing-library/react";
 import configureStore from 'redux-mock-store';
@@ -8,20 +8,26 @@ import browserHistory from "../../history";
 
 const mockStore = configureStore({});
 
-describe(`Header tests`, () => {
+const wrapper = ({children}) => (
+  <Provider store={mockStore({
+    USER: {
+      user: null
+    }
+  })}>
+    <Router history={browserHistory}>
+      {children}
+    </Router>
+  </Provider>
+);
+
+describe(`Header`, () => {
   it(`Should Header render correctly`, () => {
-    const {container} = render(
-        <redux.Provider store={mockStore({
-          USER: {
-            user: null
-          }
-        })}>
-          <Router history={browserHistory}>
-            <Header
-              isFavoriteScreen={false}
-            />
-          </Router>
-        </redux.Provider>);
+    const {container} = render(<Header isFavoriteScreen={false} />, {wrapper});
+    expect(container).toMatchSnapshot();
+  });
+
+  it(`Should Header render correctly when is not favorite Screen`, () => {
+    const {container} = render(<Header isFavoriteScreen />, {wrapper});
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/utils/test-utils.jsx
+++ b/src/utils/test-utils.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import {Router} from 'react-router-dom';
+import {render as pureRender} from "@testing-library/react";
+import {Provider} from "react-redux";
+import configureStore from "redux-mock-store";
+import browserHistory from "../history";
+
+const render = (
+    ui, {
+      store = {},
+      ...otherOptions
+    }) => {
+  const wrapper = ({children}) => (
+    <Provider store={configureStore()(store)}>
+      <Router history={browserHistory}>
+        {children}
+      </Router>
+    </Provider>
+  );
+  return pureRender(ui, {wrapper, ...otherOptions});
+};
+
+// Реэкспортим библиотеку, чтобы не нужно было ее подключать.
+export * from '@testing-library/react';
+export {render};


### PR DESCRIPTION
Добавил несколько вариантов врапперов:
1. в `Header` простой вариант: прямо в тесте создаем враппер и подключаем к рендеру
2. в `favorites-empty-screen` боле сложный вариант, но универсальный: Создаем кастомный рендер (прокси над рендером), в котором устанавливаем роутер и редакс (с возможностью прокидывать данные)